### PR TITLE
Change max offsets to uint32_t

### DIFF
--- a/appvar.h
+++ b/appvar.h
@@ -20,7 +20,7 @@ typedef struct {
     uint8_t *output;
     uint8_t curr_image;
     uint8_t max_data;
-    uint16_t offsets[MAX_OFFSETS];
+    uint32_t offsets[MAX_OFFSETS];
     unsigned int offset;
     unsigned int start;
     char *string;


### PR DESCRIPTION
When you export a compressed appvar, but with uncompressed offsets, some offsets might be more than 65535, while it still fits in the appvar, because compression.